### PR TITLE
Navbar translúcida y comportamiento botón Back (Android)

### DIFF
--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -9,4 +9,5 @@
   <color name="secondary_text">#757575</color>
   <color name="divider">#bdbdbd</color>
   <color name="dark_divider">#e9e9e9</color>
+  <color name="background_color">#fafafa</color>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -6,6 +6,8 @@
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/dark_primary</item>
 
+        <!-- Navbar translucid -->
+        <item name="android:windowTranslucentNavigation">true</item>
         <!-- cursor -->
         <item name="colorControlActivated">@color/accent</item>
     </style>

--- a/index.android.js
+++ b/index.android.js
@@ -4,7 +4,8 @@ import {
   StyleSheet,
   Text,
   View,
-  Navigator
+  Navigator,
+  BackAndroid
 } from 'react-native';
 
 import Root from './root';
@@ -16,6 +17,17 @@ export default class TrendingSeriesClient extends Component {
   renderScene(route, navigator) {
     console.log(route);
 
+    // comportamiento del botón Back de Android según la escena
+    BackAndroid.addEventListener('hardwareBackPress', () => {
+      if (route.name == 'root') {
+        return true;
+      } else if(route.name == 'search') {
+        navigator.pop();
+        return true;
+      }
+    });
+
+    // qué vista cargar en el navigator
     if (route.name == 'root') {
       return <Root navigator={navigator} />
     }

--- a/search.android.js
+++ b/search.android.js
@@ -130,11 +130,12 @@ const styles = StyleSheet.create({
     //alignItems: 'center',
     backgroundColor: '#fafafa',
     //padding: 10,
-    paddingTop: 56
+    paddingTop: 80
   },
   nav: {
     elevation: 6,
     backgroundColor: '#3e50b4',
+    marginTop: 24
   },
   titleView: {
     flex: 1,


### PR DESCRIPTION
Android Navbar
---------------------
Primero la personalizaremos para que sea translúcida.
Que pase de esto:
![Black solid Android Navbar](https://trello-attachments.s3.amazonaws.com/586c0ef1cc7d85fce1399f50/480x71/58e45a0bc0ca5103376f6c0f7dc26c76/NavBarSolid.png)

a esto:
![Translucid Android Navbar](https://trello-attachments.s3.amazonaws.com/586c0ef1cc7d85fce1399f50/480x71/112404d39427d95394f651734fc4e0e0/NavBarTranslucid.png)

Esto conlleva un problema que hace que la `Status bar` de Android de arriba se pueda atravesar por las vistas de la aplicación, por lo que deberemos modificar el estilo del `navigator` para bajarlo y que no esté detrás de la `Status bar`.

Android Back Navbar Button
-------------------------------------
Aprovecharemos también para en la vista índice (lo hará efectiva en todas) implementar el comportamiento del botón `Back` en Android, para que vuelva a una vista anterior, no haga nada, cierre la aplicación, etc. Lo haremos con el componente `BackAndroid` de `React Native`.

![Back Android Navbar Button](https://trello-attachments.s3.amazonaws.com/586c0ef1cc7d85fce1399f50/200x134/6137386be7d6cbc2910d5bb9e86d847a/cargar_el_3_1_2017_a_las_22_06_32.png)