### PR TITLE
Ver serie (ficha serie)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -96,6 +96,14 @@ android {
             abiFilters "armeabi-v7a", "x86"
         }
     }
+    signingConfigs {
+      release {
+        storeFile file(MYAPP_RELEASE_STORE_FILE)
+        storePassword MYAPP_RELEASE_STORE_PASSWORD
+        keyAlias MYAPP_RELEASE_KEY_ALIAS
+        keyPassword MYAPP_RELEASE_KEY_PASSWORD
+      }
+    }
     splits {
         abi {
             reset()
@@ -108,6 +116,7 @@ android {
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            signingConfig signingConfigs.release
         }
     }
     // applicationVariants are e.g. debug, release

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf8"?>
+<?xml version="1.0" ?>
 <resources>
   <color name="dark_primary">#2f3e9e</color>
   <color name="primary">#3e50b4</color>

--- a/components/circularButton.android.js
+++ b/components/circularButton.android.js
@@ -1,0 +1,71 @@
+import React, { Component } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableNativeFeedback,
+  Platform
+} from 'react-native';
+import Icon from 'react-native-vector-icons/Ionicons';
+
+class circularButton extends Component {
+  render() {
+    return (
+      <View style={
+        [
+          {
+            width: this.props.size,
+            height: this.props.size,
+            backgroundColor: this.props.backgroundColor,
+            borderRadius: this.props.size,
+          },
+          styles.externalView,
+          this.props.style,
+        ]
+      }>
+
+        <TouchableNativeFeedback
+          disabled={this.props.disabled}
+          background={TouchableNativeFeedback.Ripple(this.props.opacityColor, true)}
+        >
+          <View style={
+            [
+              {
+                width: this.props.size,
+                height: this.props.size,
+                backgroundColor: 'transparent'
+              },
+              styles.interiorView,
+            ]
+          }>
+            <Icon style={
+              [
+                {
+                  fontSize: this.props.iconSize,
+                  color: (this.props.disabled) ? 'rgba(255, 255, 255, 0.2)' : this.props.iconColor,
+                },
+                styles.icon,
+              ]}
+              name={this.props.icon}
+            />
+          </View>
+        </TouchableNativeFeedback>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  externalView: {
+  },
+  interiorView: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  icon: {
+    paddingRight: 2,
+    paddingBottom: 2,
+  },
+});
+
+export default circularButton;

--- a/components/circularButton.android.js
+++ b/components/circularButton.android.js
@@ -4,11 +4,23 @@ import {
   Text,
   View,
   TouchableNativeFeedback,
-  Platform
+  Platform,
+  Linking,
 } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
 
 class circularButton extends Component {
+
+  checkAndOpenLink(url) {
+    Linking.canOpenURL(url).then(supported => {
+      if (!supported) {
+        console.log('Error: no podemos linkear la url - ' + url);
+      } else {
+        return Linking.openURL(url);
+      }
+    }).catch(err => console.error('Ha ocurrido un error linkeando', err));
+  }
+
   render() {
     return (
       <View style={
@@ -27,6 +39,7 @@ class circularButton extends Component {
         <TouchableNativeFeedback
           disabled={this.props.disabled}
           background={TouchableNativeFeedback.Ripple(this.props.opacityColor, true)}
+          onPress={(this.props.link) ? () => this.checkAndOpenLink(this.props.onPress) : this.props.onPress}
         >
           <View style={
             [

--- a/components/circularButton.ios.js
+++ b/components/circularButton.ios.js
@@ -5,10 +5,22 @@ import {
   View,
   TouchableOpacity,
   Platform,
+  Linking,
 } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
 
 class circularButton extends Component {
+
+  checkAndOpenLink(url) {
+    Linking.canOpenURL(url).then(supported => {
+      if (!supported) {
+        console.log('Error: no podemos linkear la url - ' + url);
+      } else {
+        return Linking.openURL(url);
+      }
+    }).catch(err => console.error('Ha ocurrido un error linkeando', err));
+  }
+
   render() {
     return (
       <View style={
@@ -31,7 +43,9 @@ class circularButton extends Component {
             },
             styles.touchableOpacity,
           ]
-      }>
+        }
+        onPress={(this.props.link) ? () => this.checkAndOpenLink(this.props.onPress) : this.props.onPress}
+      >
         <View style={
           [
             {

--- a/components/circularButton.ios.js
+++ b/components/circularButton.ios.js
@@ -1,0 +1,77 @@
+import React, { Component } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  Platform,
+} from 'react-native';
+import Icon from 'react-native-vector-icons/Ionicons';
+
+class circularButton extends Component {
+  render() {
+    return (
+      <View style={
+        [
+          {
+            width: this.props.size,
+            height: this.props.size,
+            backgroundColor: this.props.backgroundColor,
+            borderRadius: this.props.size,
+          },
+          styles.externalView,
+          this.props.style,
+        ]
+      }>
+      <TouchableOpacity disabled={this.props.disabled} style={
+          [
+            {
+              borderRadius: this.props.size,
+              borderColor: (this.props.disabled) ? 'rgba(255, 255, 255, 0.2)' : this.props.iconColor,
+            },
+            styles.touchableOpacity,
+          ]
+      }>
+        <View style={
+          [
+            {
+              width: this.props.size,
+              height: this.props.size,
+              backgroundColor: 'transparent'
+            },
+            styles.interiorView,
+          ]
+        }>
+          <Icon style={
+            [
+              {
+                fontSize: this.props.iconSize,
+                color: (this.props.disabled) ? 'rgba(255, 255, 255, 0.2)' : this.props.iconColor,
+              },
+              styles.icon,
+            ]}
+            name={this.props.icon}
+          />
+        </View>
+      </TouchableOpacity>
+    </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  externalView: {
+  },
+  interiorView: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  touchableOpacity: {
+    borderWidth: 1,
+  },
+  icon: {
+    paddingRight: 2,
+  },
+});
+
+export default circularButton;

--- a/components/seasonButton.android.js
+++ b/components/seasonButton.android.js
@@ -1,0 +1,103 @@
+import React, { Component } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableNativeFeedback,
+  Platform,
+  Image
+} from 'react-native';
+import Icon from 'react-native-vector-icons/Ionicons';
+
+class seasonButton extends Component {
+  render() {
+    return (
+      <View style={
+        [
+          {
+            width: this.props.width,
+            height: this.props.height,
+            backgroundColor: this.props.backgroundColor,
+            borderRadius: this.props.borderRadius,
+          },
+          styles.externalView,
+          this.props.style,
+        ]
+      }>
+        <TouchableNativeFeedback
+          disabled={this.props.disabled}
+          background={TouchableNativeFeedback.Ripple(this.props.opacityColor, true)}
+        >
+          <View style={
+            [
+              {
+                width: this.props.width,
+                height: this.props.height,
+                backgroundColor: 'transparent'
+              },
+              styles.interiorView,
+            ]
+          }>
+            <Image style={
+                [
+                  {
+                    height: this.props.imageHeight,
+                    width: this.props.imageWidth,
+                    resizeMode: this.props.resizeMode,
+                    zIndex: -3
+                  }
+                ]
+              }
+              source={{uri: this.props.source}}
+            />
+            <View style={styles.titleAndSubtitle}>
+              <Text style={
+                  [
+                    {
+                      fontSize: this.props.titleSize,
+                      color: this.props.titleColor,
+                    },
+                    styles.title,
+                  ]
+                }>{this.props.title}
+              </Text>
+              <Text style={
+                  [
+                    {
+                      fontSize: this.props.subtitleSize,
+                      color: this.props.subtitleColor,
+                    },
+                    styles.subtitle,
+                  ]
+                }>{this.props.subtitle}
+              </Text>
+            </View>
+          </View>
+        </TouchableNativeFeedback>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  externalView: {
+    padding: 2,
+    marginRight: 2,
+  },
+  interiorView: {
+  },
+  touchableOpacity: {
+  },
+  titleAndSubtitle: {
+    padding: 8,
+    paddingLeft: 4,
+  },
+  title: {
+    fontFamily: 'Roboto-Medium',
+  },
+  subtitle: {
+    fontFamily: 'Roboto-Medium',
+  },
+});
+
+export default seasonButton;

--- a/components/seasonButton.ios.js
+++ b/components/seasonButton.ios.js
@@ -1,0 +1,107 @@
+import React, { Component } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  Platform,
+  Image,
+} from 'react-native';
+import Icon from 'react-native-vector-icons/Ionicons';
+
+class seasonButton extends Component {
+  render() {
+    return (
+      <View style={
+        [
+          {
+            width: this.props.width,
+            height: this.props.height,
+            backgroundColor: this.props.backgroundColor,
+            borderRadius: this.props.borderRadius,
+          },
+          styles.externalView,
+          this.props.style,
+        ]
+      }>
+        <TouchableOpacity disabled={this.props.disabled} style={
+            [
+              {
+                borderRadius: this.props.borderRadius,
+                borderColor: (this.props.disabled) ? 'rgba(255, 255, 255, 0.2)' : this.props.iconColor,
+              },
+              styles.touchableOpacity,
+            ]
+        }>
+          <View style={
+            [
+              {
+                width: this.props.width,
+                height: this.props.height,
+                backgroundColor: 'transparent'
+              },
+              styles.interiorView,
+            ]
+          }>
+            <Image style={
+                [
+                  {
+                    height: this.props.imageHeight,
+                    width: this.props.imageWidth,
+                    resizeMode: this.props.resizeMode,
+                  }
+                ]
+              }
+              source={{uri: this.props.source}}
+            />
+            <View style={styles.titleAndSubtitle}>
+              <Text style={
+                  [
+                    {
+                      fontSize: this.props.titleSize,
+                      color: this.props.titleColor,
+                    },
+                    styles.title,
+                  ]
+                }>{this.props.title}
+              </Text>
+              <Text style={
+                  [
+                    {
+                      fontSize: this.props.subtitleSize,
+                      color: this.props.subtitleColor,
+                    },
+                    styles.subtitle,
+                  ]
+                }>{this.props.subtitle}
+              </Text>
+            </View>
+          </View>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  externalView: {
+    padding: 2,
+    marginRight: 2,
+  },
+  interiorView: {
+  },
+  touchableOpacity: {
+  },
+  titleAndSubtitle: {
+    padding: 8,
+    paddingLeft: 4,
+  },
+  title: {
+    fontWeight: '500',
+  },
+  subtitle: {
+    fontWeight: '500',
+  },
+});
+
+export default seasonButton;

--- a/index.android.js
+++ b/index.android.js
@@ -49,6 +49,7 @@ export default class TrendingSeriesClient extends Component {
       <View style={styles.container}>
         <StatusBar animated backgroundColor={'#2f3e9e'} />
         <Navigator
+          style={{backgroundColor: '#3e50b4'}}
           initialRoute={{ name: 'root'}}
           renderScene={this.renderScene.bind(this)}
           configureScene={(route) => {

--- a/index.android.js
+++ b/index.android.js
@@ -11,6 +11,7 @@ import {
 
 import Root from './root';
 import Search from './search.android';
+import Series from './series';
 import SearchResults from './searchResults';
 
 export default class TrendingSeriesClient extends Component {
@@ -35,6 +36,9 @@ export default class TrendingSeriesClient extends Component {
     if (route.name == 'search') {
       return <Search navigator={navigator} />
     }
+    if (route.name == 'series') {
+      return <Series navigator={navigator} {...route.passProps} />
+    }
     if (route.name == 'searchResults') {
       return <SearchResults navigator={navigator} {...route.passProps} />
     }
@@ -50,6 +54,8 @@ export default class TrendingSeriesClient extends Component {
           configureScene={(route) => {
             if (route.name == 'search') {
               return Navigator.SceneConfigs.FadeAndroid;
+            } else if(route.name == 'series') {
+              return Navigator.SceneConfigs.FloatFromBottomAndroid;
             } else {
               return Navigator.SceneConfigs.FloatFromBottomAndroid;
             }

--- a/index.ios.js
+++ b/index.ios.js
@@ -37,6 +37,7 @@ export default class TrendingSeriesClient extends Component {
       <View style={styles.container}>
         <StatusBar animated />
         <Navigator
+          style={{backgroundColor: '#3e50b4'}}
           initialRoute={{ name: 'root'}}
           renderScene={this.renderScene.bind(this)}
           configureScene={(route) => {

--- a/index.ios.js
+++ b/index.ios.js
@@ -10,6 +10,7 @@ import {
 
 import Root from './root';
 import Search from './search.ios';
+import Series from './series';
 import SearchResults from './searchResults';
 
 export default class TrendingSeriesClient extends Component {
@@ -22,6 +23,9 @@ export default class TrendingSeriesClient extends Component {
     }
     if (route.name == 'search') {
       return <Search navigator={navigator} />
+    }
+    if (route.name == 'series') {
+      return <Series navigator={navigator} {...route.passProps} />
     }
     if (route.name == 'searchResults') {
       return <SearchResults navigator={navigator} {...route.passProps} />
@@ -38,6 +42,8 @@ export default class TrendingSeriesClient extends Component {
           configureScene={(route) => {
             if (route.name == 'search') {
               return Navigator.SceneConfigs.PushFromRight;
+            } else if (route.name == 'series') {
+              return Navigator.SceneConfigs.FloatFromBottom;
             } else {
               return Navigator.SceneConfigs.PushFromRight;
             }

--- a/ios/TrendingSeriesClient.xcodeproj/project.pbxproj
+++ b/ios/TrendingSeriesClient.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -23,6 +22,7 @@
 		140ED2AC1D01E1AD002B40FF /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
+		6227C6821E2828F200013BFB /* YTPlayerView-iframe-player.html in Resources */ = {isa = PBXBuildFile; fileRef = 6227C6811E2828F200013BFB /* YTPlayerView-iframe-player.html */; };
 		6247200B1E21A1B600B03D38 /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 624720011E21A1B600B03D38 /* Entypo.ttf */; };
 		6247200C1E21A1B600B03D38 /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 624720021E21A1B600B03D38 /* EvilIcons.ttf */; };
 		6247200D1E21A1B600B03D38 /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 624720031E21A1B600B03D38 /* FontAwesome.ttf */; };
@@ -34,6 +34,7 @@
 		624720131E21A1B600B03D38 /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 624720091E21A1B600B03D38 /* SimpleLineIcons.ttf */; };
 		624720141E21A1B600B03D38 /* Zocial.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6247200A1E21A1B600B03D38 /* Zocial.ttf */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
+		17690FBA4B334A6082F05145 /* libRCTYouTube.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A455FE9DE0EB4868BC0AF38B /* libRCTYouTube.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -242,6 +243,7 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = TrendingSeriesClient/main.m; sourceTree = "<group>"; };
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
+		6227C6811E2828F200013BFB /* YTPlayerView-iframe-player.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "YTPlayerView-iframe-player.html"; sourceTree = "<group>"; };
 		624720011E21A1B600B03D38 /* Entypo.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Entypo.ttf; sourceTree = "<group>"; };
 		624720021E21A1B600B03D38 /* EvilIcons.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = EvilIcons.ttf; sourceTree = "<group>"; };
 		624720031E21A1B600B03D38 /* FontAwesome.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = FontAwesome.ttf; sourceTree = "<group>"; };
@@ -254,6 +256,8 @@
 		6247200A1E21A1B600B03D38 /* Zocial.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Zocial.ttf; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
+		FB59BD5C26AE438093927544 /* RCTYouTube.xcodeproj */ = {isa = PBXFileReference; name = "RCTYouTube.xcodeproj"; path = "../node_modules/react-native-youtube/RCTYouTube.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		A455FE9DE0EB4868BC0AF38B /* libRCTYouTube.a */ = {isa = PBXFileReference; name = "libRCTYouTube.a"; path = "libRCTYouTube.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -280,6 +284,7 @@
 				832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */,
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
+				17690FBA4B334A6082F05145 /* libRCTYouTube.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -373,6 +378,7 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
 				13B07FB71A68108700A75B9A /* main.m */,
+				6227C6811E2828F200013BFB /* YTPlayerView-iframe-player.html */,
 			);
 			name = TrendingSeriesClient;
 			sourceTree = "<group>";
@@ -441,6 +447,7 @@
 				832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */,
 				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
+				FB59BD5C26AE438093927544 /* RCTYouTube.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -521,7 +528,7 @@
 		83CBB9F71A601CBA00E9B192 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 610;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					00E356ED1AD99517003FC87E = {
@@ -791,6 +798,7 @@
 				6247200C1E21A1B600B03D38 /* EvilIcons.ttf in Resources */,
 				624720141E21A1B600B03D38 /* Zocial.ttf in Resources */,
 				624720131E21A1B600B03D38 /* SimpleLineIcons.ttf in Resources */,
+				6227C6821E2828F200013BFB /* YTPlayerView-iframe-player.html in Resources */,
 				6247200F1E21A1B600B03D38 /* Ionicons.ttf in Resources */,
 				6247200E1E21A1B600B03D38 /* Foundation.ttf in Resources */,
 				624720111E21A1B600B03D38 /* MaterialIcons.ttf in Resources */,
@@ -873,6 +881,10 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TrendingSeriesClient.app/TrendingSeriesClient";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 			};
 			name = Debug;
 		};
@@ -886,6 +898,10 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TrendingSeriesClient.app/TrendingSeriesClient";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 			};
 			name = Release;
 		};

--- a/ios/YTPlayerView-iframe-player.html
+++ b/ios/YTPlayerView-iframe-player.html
@@ -1,0 +1,90 @@
+<!--
+     Copyright 2014 Google Inc. All rights reserved.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+    body { margin: 0; width:100%%; height:100%%;  background-color:#000000; }
+    html { width:100%%; height:100%%; background-color:#000000; }
+
+    .embed-container iframe,
+    .embed-container object,
+    .embed-container embed {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%% !important;
+        height: 100%% !important;
+    }
+    </style>
+</head>
+<body>
+    <div class="embed-container">
+        <div id="player"></div>
+    </div>
+    <script src="https://www.youtube.com/iframe_api"></script>
+    <script>
+    var player;
+    var error = false;
+
+    YT.ready(function() {
+        player = new YT.Player('player', %@);
+        player.setSize(window.innerWidth, window.innerHeight);
+        window.location.href = 'ytplayer://onYouTubeIframeAPIReady';
+
+        // this will transmit playTime frequently while playng
+        function getCurrentTime() {
+             var state = player.getPlayerState();
+             if (state == YT.PlayerState.PLAYING) {
+                 time = player.getCurrentTime()
+                 window.location.href = 'ytplayer://onPlayTime?data=' + time;
+             }
+        }
+        
+        window.setInterval(getCurrentTime, 250);
+             
+    });
+
+    function onReady(event) {
+        window.location.href = 'ytplayer://onReady?data=' + event.data;
+    }
+
+    function onStateChange(event) {
+        if (!error) {            
+            window.location.href = 'ytplayer://onStateChange?data=' + event.data;
+        }
+        else {
+            error = false;
+        }
+    }
+
+    function onPlaybackQualityChange(event) {
+        window.location.href = 'ytplayer://onPlaybackQualityChange?data=' + event.data;
+    }
+
+    function onPlayerError(event) {
+        if (event.data == 100) {
+            error = true;
+        }
+        window.location.href = 'ytplayer://onError?data=' + event.data;
+    }
+    
+    window.onresize = function() {
+        player.setSize(window.innerWidth, window.innerHeight);
+    }
+    </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "react": "15.4.1",
     "react-native": "^0.40.0",
     "react-native-textinput-effects": "^0.3.0",
-    "react-native-vector-icons": "^4.0.0"
+    "react-native-vector-icons": "^4.0.0",
+    "react-native-youtube": "git+https://github.com/joncursi/react-native-youtube.git"
   },
   "devDependencies": {
     "babel-jest": "18.0.0",

--- a/search.android.js
+++ b/search.android.js
@@ -86,6 +86,18 @@ class Search extends Component {
     }
   }
 
+  // redirige a la vista de ficha de serie
+  openSeries(seriesId) {
+    console.log('Ver serie con id:' + seriesId);
+    this.props.navigator.push({
+      name: 'series',
+      passProps: {
+        seriesId: seriesId,
+        backButtonText: 'Búsqueda'
+      }
+    });
+  }
+
   renderHeader() {
     return (
       <View style={styles.listHeader}>
@@ -97,7 +109,7 @@ class Search extends Component {
 
   renderRow(rowData) {
     return (
-      <TouchableOpacity style={styles.rowTouch}>
+      <TouchableOpacity style={styles.rowTouch} onPress={ () => this.openSeries(rowData.id)}>
         <View style={styles.row}>
           <View style={styles.rowTop}>
             <Image style={styles.rowImage}

--- a/search.android.js
+++ b/search.android.js
@@ -202,10 +202,12 @@ class Search extends Component {
 var NavigationBarRouteMapper = {
   LeftButton(route, navigator, index, navState) {
     return (
-      <TouchableOpacity style={styles.backButton}
-          onPress={() => navigator.parentNavigator.pop()}>
-        <Icon name="md-arrow-back" style={styles.backIcon} />
-      </TouchableOpacity>
+      <View style={styles.backButtonView}>
+        <TouchableOpacity style={styles.backButton}
+            onPress={() => navigator.parentNavigator.pop()}>
+          <Icon name="md-arrow-back" style={styles.backIcon} />
+        </TouchableOpacity>
+      </View>
     );
   },
   RightButton(route, navigator, index, navState) {
@@ -229,7 +231,7 @@ const styles = StyleSheet.create({
   nav: {
     elevation: 6,
     backgroundColor: '#3e50b4',
-    marginTop: 24
+    height: 80,
   },
   titleView: {
     flex: 1,
@@ -240,10 +242,14 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontFamily: 'Roboto-Medium'
   },
+  backButtonView: {
+    flex: 1,
+    justifyContent: 'center',
+  },
   backButton: {
     flex: 1,
     justifyContent: 'center',
-    padding: 14
+    padding: 14,
   },
   backIcon: {
     fontSize: 24,

--- a/search.ios.js
+++ b/search.ios.js
@@ -86,6 +86,18 @@ class Search extends Component {
     }
   }
 
+  // redirige a la vista de ficha de serie
+  openSeries(seriesId) {
+    console.log('Ver serie con id:' + seriesId);
+    this.props.navigator.push({
+      name: 'series',
+      passProps: {
+        seriesId: seriesId,
+        backButtonText: 'Búsqueda'
+      }
+    });
+  }
+
   renderHeader() {
     return (
       <View style={styles.listHeader}>
@@ -97,7 +109,7 @@ class Search extends Component {
 
   renderRow(rowData) {
     return (
-      <TouchableOpacity style={styles.rowTouch}>
+      <TouchableOpacity style={styles.rowTouch} onPress={ () => this.openSeries(rowData.id)}>
         <View style={styles.row}>
           <View style={styles.rowTop}>
             <Image style={styles.rowImage}

--- a/series.js
+++ b/series.js
@@ -36,6 +36,7 @@ class Series extends Component {
       fetchEnded: false,
       seriesData: {},
       seriesGenres: '',
+      imdbRating: 0,
       scrollY: new Animated.Value(0),
       posterOpacity: new Animated.Value(0),
       fanartOpacity: new Animated.Value(0),
@@ -82,6 +83,8 @@ class Series extends Component {
       this.setState({seriesData: data});
       // procesamos los generos
       this.setState({seriesGenres : data.genre.join(', ')});
+      // procesamos la nota media
+      this.setState({imdbRating: (data.imdbRating).toFixed(1)});
     }
   }
 
@@ -159,7 +162,7 @@ class Series extends Component {
         >
           <View style={styles.scrollViewContent}>
             <View style={styles.zIndexFix} />
-            </*header*/View style={styles.headerContent}>
+            <View style={styles.headerContent}>
               <Animated.Image style={[styles.poster, {opacity: this.state.posterOpacity}]} source={{uri: this.state.seriesData.poster}} onLoadEnded={this.onPosterLoadEnded()} />
               <View style={styles.seriesTitleSubtitleGenre}>
                 <Text style={styles.seriesTitle} numberOfLines={1}>{this.state.seriesData.seriesName}</Text>
@@ -168,7 +171,7 @@ class Series extends Component {
               </View>
               <View style={styles.ratingAndRuntimeView}>
                 <Text style={styles.ratingText}>
-                  <Icon name={(Platform.OS === 'ios') ? 'ios-star' : 'md-star'} style={styles.ratingIcon}/> 4,7
+                  <Icon name={(Platform.OS === 'ios') ? 'ios-star' : 'md-star'} style={styles.ratingIcon}/> {this.state.imdbRating}
                 </Text>
                 <Text style={styles.runtimeText} numberOfLines={1}>
                   <Icon name={(Platform.OS === 'ios') ? 'ios-time-outline' : 'md-time'} /> {this.state.seriesData.runtime} min
@@ -179,11 +182,10 @@ class Series extends Component {
               </View>
             </View>
 
-            </*body*/View style={styles.bodyContent}>
+            <View style={styles.bodyContent}>
 
               <View style={styles.principalButtons}>
-                <CircularButton/* los tres botones principales de la vista*/
-                  disabled
+                <CircularButton
                   size={(Platform.OS === 'ios') ? 35 : 40}
                   backgroundColor={'transparent'}
                   opacityColor={'#fe3f80'}
@@ -191,6 +193,9 @@ class Series extends Component {
                   iconSize={20}
                   iconColor={(Platform.OS === 'ios') ? '#aaaaaa' : '#bbbbc1'}
                   style={{marginRight: 30}}
+                  disabled={(this.state.seriesData.trailer) ? false : true}
+                  link
+                  onPress={'https://www.youtube.com/watch?v=' + this.state.seriesData.trailer}
                 />
                 <CircularButton
                   size={(Platform.OS === 'ios') ? 45 : 55}
@@ -211,23 +216,23 @@ class Series extends Component {
                 />
               </View>
 
-              <Text numberOfLines={3} style={styles.overview}>{this.state.seriesData.overview}/*encontrar manera de animar con mostrar más mostrar menos... altura?*/</Text>
+              <Text numberOfLines={3} style={styles.overview}>{this.state.seriesData.overview}</Text>
             </View>
 
-            </*footer*/View style={styles.footerContent}/*reparto y estado*/>
+            <View style={styles.footerContent}>
               <View style={styles.footerTitleView}>
                 <Text style={styles.footerTitle}>Guionista/s</Text>
                 <Text style={styles.footerTitle}>Reparto</Text>
                 <Text style={styles.footerTitle}>Estado</Text>
               </View>
               <View style={styles.footerDataView}>
-                <Text style={styles.footerData} numberOfLines={1}>Matt Duffer, Ross Duffer</Text>
-                <Text style={styles.footerData} numberOfLines={1}>Winona Ryder, Millie Brown, Noah</Text>
+                <Text style={styles.footerData} numberOfLines={1}>{this.state.seriesData.writer}</Text>
+                <Text style={styles.footerData} numberOfLines={1}>{this.state.seriesData.actors}</Text>
                 <Text style={styles.footerData}>{(this.state.seriesData.status === 'Ended' ? 'Finalizada' : 'Continuada')}</Text>
               </View>
             </View>
 
-            </*anexo: temporadas, de prueba, procesar esto cuando llegue el momento!*/View style={styles.seasonsContent}>
+            <View style={styles.seasonsContent}>
               <ScrollView horizontal style={styles.scrollH}>
 
                 <SeasonButton
@@ -235,7 +240,7 @@ class Series extends Component {
                   imageHeight={(Platform.OS === 'ios') ? 159 : 173}
                   backgroundColor={'#212121'}
                   opacityColor={'#fe3f80'}
-                  source={'https://thetvdb.com/banners/seasons/305288-1-3.jpg'/*animar opacidad al cargar?*/}
+                  source={'https://thetvdb.com/banners/seasons/305288-1-3.jpg'}
                   title={'Temporada 1'}
                   titleSize={(Platform.OS === 'ios') ? 13 : 14}
                   titleColor={'#dedede'}

--- a/series.js
+++ b/series.js
@@ -37,6 +37,8 @@ class Series extends Component {
       seriesData: {},
       seriesGenres: '',
       scrollY: new Animated.Value(0),
+      posterOpacity: new Animated.Value(0),
+      fanartOpacity: new Animated.Value(0),
     }
   }
 
@@ -83,6 +85,22 @@ class Series extends Component {
     }
   }
 
+  /* animaciones */
+  onPosterLoadEnded() {
+    Animated.timing(this.state.posterOpacity, {
+      toValue: 1,
+      duration: 500
+    }).start();
+  }
+
+  onFanartLoadEnded() {
+    Animated.timing(this.state.fanartOpacity, {
+      toValue: 1,
+      duration: 500
+    }).start();
+  }
+
+  /* render */
   render() {
     return (
       <View style={styles.statusBarAndNavView}>
@@ -125,11 +143,12 @@ class Series extends Component {
         <Animated.View style={[styles.topBarOverlay, {opacity: topBarOpacity}]} />
         <View style={styles.fanArtOverlay} />
         <Animated.Image style={[
-          styles.fanArt,
-          {transform: [{translateY: imageTranslate}]},
-            /*TODO: {opacity: this.state.fanArt}, usar algo asi para animar la opacidad*/
+            styles.fanArt,
+            {transform: [{translateY: imageTranslate}]},
+            {opacity: this.state.fanartOpacity},
           ]}
           source={{uri: this.state.seriesData.fanart}}
+          onLoadEnded={this.onFanartLoadEnded()}
         />
 
         <ScrollView style={styles.scrollViewV}
@@ -141,7 +160,7 @@ class Series extends Component {
           <View style={styles.scrollViewContent}>
             <View style={styles.zIndexFix} />
             </*header*/View style={styles.headerContent}>
-              <Image style={styles.poster} source={{uri: this.state.seriesData.poster}} />
+              <Animated.Image style={[styles.poster, {opacity: this.state.posterOpacity}]} source={{uri: this.state.seriesData.poster}} onLoadEnded={this.onPosterLoadEnded()} />
               <View style={styles.seriesTitleSubtitleGenre}>
                 <Text style={styles.seriesTitle} numberOfLines={1}>{this.state.seriesData.seriesName}</Text>
                 <Text style={styles.seriesSubtitle}>{new Date(this.state.seriesData.firstAired).getFullYear()}   <Text numberOfLines={1}>{this.state.seriesData.rating}</Text></Text>
@@ -216,7 +235,7 @@ class Series extends Component {
                   imageHeight={(Platform.OS === 'ios') ? 159 : 173}
                   backgroundColor={'#212121'}
                   opacityColor={'#fe3f80'}
-                  source={'https://thetvdb.com/banners/seasons/305288-1-3.jpg'}
+                  source={'https://thetvdb.com/banners/seasons/305288-1-3.jpg'/*animar opacidad al cargar?*/}
                   title={'Temporada 1'}
                   titleSize={(Platform.OS === 'ios') ? 13 : 14}
                   titleColor={'#dedede'}
@@ -512,7 +531,6 @@ const styles = StyleSheet.create({
   },
   seriesSubtitle: {
     color: '#bbbbc1',
-    backgroundColor: 'transparent',
     ...Platform.select({
       ios: {
         marginTop: 10,
@@ -528,7 +546,6 @@ const styles = StyleSheet.create({
   },
   seriesGenre: {
     color: '#bbbbc1',
-    backgroundColor: 'transparent',
     ...Platform.select({
       ios: {
         fontSize: 12.5,
@@ -573,7 +590,6 @@ const styles = StyleSheet.create({
   },
   runtimeText: {
     color: '#eaeaea',
-    backgroundColor: 'transparent',
     textAlign: 'right',
     ...Platform.select({
       ios: {
@@ -592,7 +608,6 @@ const styles = StyleSheet.create({
   },
   networkText: {
     color: '#eaeaea',
-    backgroundColor: 'transparent',
     textAlign: 'right',
     ...Platform.select({
       ios: {
@@ -615,6 +630,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#212121',
   },
   principalButtons: {
+    backgroundColor: '#212121',
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
@@ -626,13 +642,14 @@ const styles = StyleSheet.create({
       },
       android: {
         justifyContent: 'center',
-        marginBottom: 7,
+        marginBottom: 2,
       }
     }),
   },
   overview: {
     color: '#bbbbc1',
-    backgroundColor: 'transparent',
+    backgroundColor: '#212121',
+    paddingBottom: 20,
     ...Platform.select({
       ios: {
         fontSize: 14,
@@ -650,7 +667,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     paddingLeft: 20,
     paddingRight: 20,
-    marginTop: 20,
+    backgroundColor: '#212121',
   },
   footerTitleView: {
     flexDirection: 'column',

--- a/series.js
+++ b/series.js
@@ -1,0 +1,156 @@
+import React, { Component } from 'react';
+import {
+  StyleSheet,
+  Platform,
+  Text,
+  View,
+  Navigator,
+  TouchableHighlight,
+  TouchableOpacity,
+  StatusBar,
+  Alert,
+} from 'react-native';
+import Icon from 'react-native-vector-icons/Ionicons';
+
+class Series extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      seriesId: this.props.seriesId,
+      fetchEnded: false,
+      seriesData: {},
+    }
+  }
+
+  errorAndPop() {
+    Alert.alert('Error', 'Lamentablemente no se han podido cargar los datos de la serie');
+    this.props.navigator.pop();
+  }
+
+  componentWillMount() {
+    console.log('Consulta serie id: ' + this.state.seriesId);
+    // segun la plataforma, url
+    const URL = (Platform.OS === 'ios') ?
+      'http://localhost:9000/api/series/' : 'http://192.168.1.13:9000/api/series/';
+
+    // hacemos fetch a la API
+    fetch(URL + this.state.seriesId, {method: "GET"})
+    .then((response) => response.json())
+    .then((responseData) => {
+      // procesamos datos
+      this.processData(responseData);
+    }).then( () => {
+      // indicamos que fetch ha terminado
+      this.setState({fetchEnded: true});
+    }).catch((error) => {
+      this.errorAndPop();
+    });
+  }
+
+  processData(data) {
+    // si la API nos devuelve que no ha encontrado nada
+    if (data.error != undefined) {
+      if (data.error == 'Not Found') {
+        // id no encontrada
+      } else {
+        // otro tipo de error interno
+      }
+      // mostramos error y volvemos atrás
+      this.errorAndPop();
+    } else {
+      // cargamos datos en el state
+      this.setState({seriesData: data});
+    }
+  }
+
+  render() {
+    return (
+      <View style={styles.statusBarAndNavView}>
+        <StatusBar
+          animated
+          translucent
+          barStyle="light-content"
+          backgroundColor={'transparent'}
+        />
+        <Navigator
+          renderScene={this.renderScene.bind(this)}
+          navigator={this.props.navigator}
+          navigationBar={
+            <Navigator.NavigationBar
+              routeMapper={NavigationBarRouteMapper(this.props)}
+              style={styles.nav} />
+          }
+        />
+      </View>
+    );
+  }
+
+  renderScene(route, navigator) {
+    return (
+      <View style={styles.containerDark}>
+        <Text style={{color: 'white', padding: 100}}>{this.state.seriesData.seriesName}</Text>
+      </View>
+    );
+  }
+
+}
+
+var NavigationBarRouteMapper = props => ({
+  LeftButton(route, navigator, index, navState) {
+    return (
+      <TouchableOpacity style={styles.backButton}
+          onPress={() => navigator.parentNavigator.pop()}>
+        <Icon name="ios-arrow-back" style={styles.backIcon} />
+        <Text style={styles.backButtonText}>
+
+        </Text>
+      </TouchableOpacity>
+    );
+  },
+  RightButton(route, navigator, index, navState) {
+    return null;
+  },
+  Title(route, navigator, index, navState) {
+    return (
+      <View style={styles.titleView}>
+        <Text style={styles.titleText}>
+
+        </Text>
+      </View>
+    );
+  }
+});
+
+const styles = StyleSheet.create({
+  statusBarAndNavView: {
+    flex: 1,
+  },
+  containerDark: {
+    flex: 1,
+    justifyContent: 'flex-start',
+    backgroundColor: '#212121',
+  },
+  backButton: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    padding: 8.5,
+    paddingTop: 5.5
+  },
+  backButtonText: {
+    fontSize: 17,
+    color: '#c0c5ff',
+    marginTop: 6,
+    marginLeft: 6,
+  },
+  backIcon: {
+    fontSize: 33,
+    color: '#dddddd',
+    shadowColor: '#000000',
+    shadowOffset: {
+    },
+    shadowOpacity: 0.8,
+  },
+});
+
+export default Series;

--- a/series.js
+++ b/series.js
@@ -9,8 +9,18 @@ import {
   TouchableOpacity,
   StatusBar,
   Alert,
+  ScrollView,
+  Image,
 } from 'react-native';
+
+const TouchableNativeFeedback = Platform.select({
+  android: () => require('TouchableNativeFeedback'),
+  ios: () => null,
+})();
+
 import Icon from 'react-native-vector-icons/Ionicons';
+import CircularButton from './components/circularButton';
+import SeasonButton from './components/seasonButton';
 
 class Series extends Component {
   constructor(props) {
@@ -19,6 +29,7 @@ class Series extends Component {
       seriesId: this.props.seriesId,
       fetchEnded: false,
       seriesData: {},
+      seriesGenres: '',
     }
   }
 
@@ -60,6 +71,8 @@ class Series extends Component {
     } else {
       // cargamos datos en el state
       this.setState({seriesData: data});
+      // procesamos los generos
+      this.setState({seriesGenres : data.genre.join(', ')});
     }
   }
 
@@ -86,9 +99,168 @@ class Series extends Component {
   }
 
   renderScene(route, navigator) {
+
     return (
       <View style={styles.containerDark}>
-        <Text style={{color: 'white', padding: 100}}>{this.state.seriesData.seriesName}</Text>
+        <View style={styles.topBarOverlay/*TODO: animar la opacidad*/} />
+        <View style={styles.fanArtOverlay} />
+        <Image style={[styles.fanArt,/*TODO: usar transform para PARALLAX*/
+            /*TODO: {opacity: this.state.fanArt}, usar algo asi para animar la opacidad*/
+          ]}
+          source={{uri: this.state.seriesData.fanart}}
+        />
+
+        <ScrollView style={styles.scrollViewV}
+          scrollEventThrottle={16}
+        >
+          <View style={styles.scrollViewContent}>
+            <View style={styles.zIndexFix} />
+            </*header*/View style={styles.headerContent}>
+              <Image style={styles.poster} source={{uri: this.state.seriesData.poster}} />
+              <View style={styles.seriesTitleSubtitleGenre}>
+                <Text style={styles.seriesTitle}>{this.state.seriesData.seriesName}</Text>
+                <Text style={styles.seriesSubtitle} numberOfLines={1}>{new Date(this.state.seriesData.firstAired).getFullYear()}   <Text numberOfLines={1}>{this.state.seriesData.rating}</Text></Text>
+                <Text style={styles.seriesGenre} numberOfLines={1}>{this.state.seriesGenres}</Text>
+              </View>
+              <View style={styles.ratingAndRuntimeView}>
+                <Text style={styles.ratingText}>
+                  <Icon name={(Platform.OS === 'ios') ? 'ios-star' : 'md-star'} style={styles.ratingIcon}/> 4,7
+                </Text>
+                <Text style={styles.runtimeText} numberOfLines={1}>
+                  <Icon name={(Platform.OS === 'ios') ? 'ios-time-outline' : 'md-time'} /> {this.state.seriesData.runtime} min
+                </Text>
+                <Text style={styles.networkText} numberOfLines={1}>
+                  <Icon name={(Platform.OS === 'ios') ? 'ios-desktop' : 'md-desktop'} /> {this.state.seriesData.network}
+                </Text>
+              </View>
+            </View>
+
+            </*body*/View style={styles.bodyContent}>
+
+              <View style={styles.principalButtons}>
+                <CircularButton/* los tres botones principales de la vista*/
+                  disabled
+                  size={(Platform.OS === 'ios') ? 35 : 40}
+                  backgroundColor={'transparent'}
+                  opacityColor={'#fe3f80'}
+                  icon={(Platform.OS === 'ios') ? 'ios-film' : 'md-film'}
+                  iconSize={20}
+                  iconColor={(Platform.OS === 'ios') ? '#aaaaaa' : '#bbbbc1'}
+                  style={{marginRight: 30}}
+                />
+                <CircularButton
+                  size={(Platform.OS === 'ios') ? 45 : 55}
+                  backgroundColor={'transparent'}
+                  opacityColor={'#fe3f80'}
+                  icon={(Platform.OS === 'ios') ? 'ios-eye' : 'md-eye'}
+                  iconSize={30}
+                  iconColor={(Platform.OS === 'ios') ? '#aaaaaa' : '#bbbbc1'}
+                />
+                <CircularButton
+                  size={(Platform.OS === 'ios') ? 35 : 40}
+                  backgroundColor={'transparent'}
+                  opacityColor={'#fe3f80'}
+                  icon={(Platform.OS === 'ios') ? 'ios-more' : 'md-more'}
+                  iconSize={20}
+                  iconColor={(Platform.OS === 'ios') ? '#aaaaaa' : '#bbbbc1'}
+                  style={{marginLeft: 30}}
+                />
+              </View>
+
+              <Text numberOfLines={3} style={styles.overview}>{this.state.seriesData.overview}/*encontrar manera de animar con mostrar más mostrar menos... altura?*/</Text>
+            </View>
+
+            </*footer*/View style={styles.footerContent}/*reparto y estado*/>
+              <View style={{marginRight: 14}}>
+                <Text style={styles.footerTitle}>Guionista/s</Text>
+                <Text style={styles.footerTitle}>Reparto</Text>
+                <Text style={styles.footerTitle}>Estado</Text>
+              </View>
+              <View>
+                <Text style={styles.footerData} numberOfLines={1}>Matt Duffer, Ross Duffer</Text>
+                <Text style={styles.footerData} numberOfLines={1}>Winona Ryder, Millie Brown, Noah</Text>
+                <Text style={styles.footerData}>{(this.state.seriesData.status === 'Ended' ? 'Finalizada' : 'Continuada')}</Text>
+              </View>
+            </View>
+
+            </*anexo: temporadas, de prueba, procesar esto cuando llegue el momento!*/View style={styles.seasonsContent}>
+              <ScrollView horizontal style={styles.scrollH}>
+
+                <SeasonButton
+                  imageWidth={(Platform.OS === 'ios') ? 110 : 120}
+                  imageHeight={(Platform.OS === 'ios') ? 159 : 173}
+                  backgroundColor={'#212121'}
+                  opacityColor={'#fe3f80'}
+                  source={'https://thetvdb.com/banners/seasons/305288-1-3.jpg'}
+                  title={'Temporada 1'}
+                  titleSize={(Platform.OS === 'ios') ? 13 : 14}
+                  titleColor={'#dedede'}
+                  subtitle={'8 episodios'}
+                  subtitleSize={(Platform.OS === 'ios') ? 13 : 14}
+                  subtitleColor={'#bbbbc1'}
+                />
+
+                <SeasonButton
+                  imageWidth={(Platform.OS === 'ios') ? 110 : 120}
+                  imageHeight={(Platform.OS === 'ios') ? 159 : 173}
+                  backgroundColor={'#212121'}
+                  opacityColor={'#fe3f80'}
+                  source={'https://thetvdb.com/banners/seasons/305288-1-3.jpg'}
+                  title={'Temporada 1'}
+                  titleSize={(Platform.OS === 'ios') ? 13 : 14}
+                  titleColor={'#dedede'}
+                  subtitle={'8 episodios'}
+                  subtitleSize={(Platform.OS === 'ios') ? 13 : 14}
+                  subtitleColor={'#bbbbc1'}
+                />
+
+                <SeasonButton
+                  imageWidth={(Platform.OS === 'ios') ? 110 : 120}
+                  imageHeight={(Platform.OS === 'ios') ? 159 : 173}
+                  backgroundColor={'#212121'}
+                  opacityColor={'#fe3f80'}
+                  source={'https://thetvdb.com/banners/seasons/305288-1-3.jpg'}
+                  title={'Temporada 1'}
+                  titleSize={(Platform.OS === 'ios') ? 13 : 14}
+                  titleColor={'#dedede'}
+                  subtitle={'8 episodios'}
+                  subtitleSize={(Platform.OS === 'ios') ? 13 : 14}
+                  subtitleColor={'#bbbbc1'}
+                />
+
+                <SeasonButton
+                  imageWidth={(Platform.OS === 'ios') ? 110 : 120}
+                  imageHeight={(Platform.OS === 'ios') ? 159 : 173}
+                  backgroundColor={'#212121'}
+                  opacityColor={'#fe3f80'}
+                  source={'https://thetvdb.com/banners/seasons/305288-1-3.jpg'}
+                  title={'Temporada 1'}
+                  titleSize={(Platform.OS === 'ios') ? 13 : 14}
+                  titleColor={'#dedede'}
+                  subtitle={'8 episodios'}
+                  subtitleSize={(Platform.OS === 'ios') ? 13 : 14}
+                  subtitleColor={'#bbbbc1'}
+                />
+
+                <SeasonButton
+                  imageWidth={(Platform.OS === 'ios') ? 110 : 120}
+                  imageHeight={(Platform.OS === 'ios') ? 159 : 173}
+                  backgroundColor={'#212121'}
+                  opacityColor={'#fe3f80'}
+                  source={'https://thetvdb.com/banners/seasons/305288-1-3.jpg'}
+                  title={'Temporada 1'}
+                  titleSize={(Platform.OS === 'ios') ? 13 : 14}
+                  titleColor={'#dedede'}
+                  subtitle={'8 episodios'}
+                  subtitleSize={(Platform.OS === 'ios') ? 13 : 14}
+                  subtitleColor={'#bbbbc1'}
+                />
+              </ScrollView>
+            </View>
+          </View>
+          {(Platform.OS === 'android') ?
+            <View style={styles.scrollPaddingBottom} /> : null}
+        </ScrollView>
       </View>
     );
   }
@@ -100,7 +272,10 @@ var NavigationBarRouteMapper = props => ({
     return (
       <TouchableOpacity style={styles.backButton}
           onPress={() => navigator.parentNavigator.pop()}>
-        <Icon name="ios-arrow-back" style={styles.backIcon} />
+        <Icon
+          name={(Platform.OS === 'ios') ? 'ios-arrow-back' : 'md-arrow-back'}
+          style={styles.backIcon}
+        />
         <Text style={styles.backButtonText}>
 
         </Text>
@@ -122,20 +297,31 @@ var NavigationBarRouteMapper = props => ({
 });
 
 const styles = StyleSheet.create({
+  // StatusBar y Navigator
   statusBarAndNavView: {
     flex: 1,
   },
-  containerDark: {
-    flex: 1,
-    justifyContent: 'flex-start',
-    backgroundColor: '#212121',
+  nav: {
+    ...Platform.select({
+      ios: {},
+      android: {
+        marginTop: 24,
+      }
+    }),
   },
   backButton: {
     flex: 1,
     flexDirection: 'row',
     justifyContent: 'center',
-    padding: 8.5,
-    paddingTop: 5.5
+    ...Platform.select({
+      ios: {
+        padding: 8.5,
+        paddingTop: 5.5,
+      },
+      android: {
+        padding: 14,
+      }
+    }),
   },
   backButtonText: {
     fontSize: 17,
@@ -144,13 +330,329 @@ const styles = StyleSheet.create({
     marginLeft: 6,
   },
   backIcon: {
-    fontSize: 33,
     color: '#dddddd',
-    shadowColor: '#000000',
-    shadowOffset: {
-    },
-    shadowOpacity: 0.8,
+    ...Platform.select({
+      ios: {
+        fontSize: 33,
+        shadowColor: '#000000',
+        shadowOffset: {
+        },
+        shadowOpacity: 0.8,
+      },
+      android: {
+        fontSize: 24,
+        elevation: 2,
+      }
+    }),
   },
+  // vista escena
+  containerDark: {
+    flex: 1,
+    justifyContent: 'flex-start',
+    backgroundColor: '#212121',
+  },
+  // barra superior (simulando navigator)
+  topBarOverlay: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    right: 0,
+    backgroundColor: 'black',
+    opacity: 0.6,/*TODO: animar*/
+    width: null,
+    ...Platform.select({
+      ios: {
+        height: 64,
+      },
+      android: {
+        height: 77,
+      }
+    }),
+    zIndex: 1,
+  },
+  // overlay oscuro para la imagen de cabecera grande
+  fanArtOverlay: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    width: null,
+    height: 200,/*TODO: se repite, pensar en globalizarla, comprobar Android*/
+    backgroundColor: 'black',
+    opacity: 0.6,
+    zIndex: -1,
+  },
+  // imagen de cabecera (fanart)
+  fanArt: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    width: null,
+    height: 200,/*TODO: se repite, pensar en globalizarla, comprobar Android*/
+    resizeMode: 'cover',
+    zIndex: -2,
+  },
+  // scrollview vertical de la vista
+  scrollViewV: {
+    flex: 1,
+  },
+  scrollViewContent: {
+    flex: 1,
+    marginTop: 200,/*TODO: se repite, pensar en globalizarla, comprobar Android*/
+    ...Platform.select({
+      ios: {
+        backgroundColor: '#212121',
+      }
+    }),
+  },
+  zIndexFix: {
+    ...Platform.select({
+      android: {
+        height: 50,
+        backgroundColor: '#212121',
+      }
+    }),
+  },
+  headerContent: {
+    flex: 1,
+    flexDirection: 'row',
+    height: 70,
+    padding: 14,
+    paddingTop: 0,
+    paddingBottom: 0,
+    ...Platform.select({
+      ios: {
+        marginTop: -22,
+      },
+      android: {
+        marginTop: -70,
+      },
+    }),
+  },
+  // imagen poster de la serie
+  poster: {
+    marginTop: -86,
+    height: 147,
+    width: 100,
+    resizeMode: 'contain',
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.1)',
+  },
+  // vista donde estan el titulo, año, content rating y generos de la serie
+  seriesTitleSubtitleGenre: {
+    flex: 1,
+    flexDirection: 'column',
+    padding: 12,
+    paddingTop: 0,
+    ...Platform.select({
+      ios: {
+        marginTop: -2
+      },
+      android: {
+        marginTop: -10,
+      }
+    }),
+  },
+  seriesTitle: {
+    color: '#eaeaea',
+    backgroundColor: 'transparent',
+    ...Platform.select({
+      ios: {
+        fontSize: 17,
+        fontWeight: '500',
+        opacity: 0.9,
+      },
+      android: {
+        fontFamily: 'Roboto-Medium',
+        fontSize: 20,
+        opacity: 0.8,
+      }
+    }),
+  },
+  seriesSubtitle: {
+    color: '#bbbbc1',
+    backgroundColor: 'transparent',
+    ...Platform.select({
+      ios: {
+        marginTop: 10,
+        fontSize: 12.5,
+        fontWeight: '200',
+      },
+      android: {
+        marginTop: 7,
+        fontFamily: 'Roboto-Light',
+        fontSize: 13,
+      }
+    }),
+  },
+  seriesGenre: {
+    color: '#bbbbc1',
+    backgroundColor: 'transparent',
+    ...Platform.select({
+      ios: {
+        fontSize: 12.5,
+        fontWeight: '200',
+      },
+      android: {
+        fontFamily: 'Roboto-Light',
+        fontSize: 13,
+      }
+    }),
+  },
+  // vista donde están la puntuacion, runtime y network de la serie
+  ratingAndRuntimeView: {
+    ...Platform.select({
+      ios: {
+        marginTop: 2,
+      },
+      android: {
+        marginTop: -3,
+      }
+    }),
+  },
+  ratingText: {
+    color: '#eaeaea',
+    backgroundColor: 'transparent',
+    textAlign: 'right',
+    ...Platform.select({
+      ios: {
+        fontSize: 12.5,
+        fontWeight: '500',
+        opacity: 0.8,
+      },
+      android: {
+        fontFamily: 'Roboto-Medium',
+        fontSize: 14,
+        opacity: 0.6,
+      }
+    }),
+  },
+  ratingIcon: {
+    fontSize: 12.5,
+  },
+  runtimeText: {
+    color: '#eaeaea',
+    backgroundColor: 'transparent',
+    textAlign: 'right',
+    ...Platform.select({
+      ios: {
+        marginTop: 12,
+        fontSize: 12.5,
+        fontWeight: '200',
+        opacity: 0.8,
+      },
+      android: {
+        marginTop: 8,
+        fontFamily: 'Roboto-Light',
+        fontSize: 13,
+        opacity: 0.6,
+      }
+    }),
+  },
+  networkText: {
+    color: '#eaeaea',
+    backgroundColor: 'transparent',
+    textAlign: 'right',
+    ...Platform.select({
+      ios: {
+        fontSize: 12.5,
+        fontWeight: '200',
+        opacity: 0.8,
+      },
+      android: {
+        fontFamily: 'Roboto-Light',
+        fontSize: 13,
+        opacity: 0.6,
+      }
+    }),
+  },
+  // contenido del cuerpo debajo de la cabecera
+  bodyContent: {
+    flex: 1,
+    paddingLeft: 20,
+    paddingRight: 20,
+    backgroundColor: '#212121',
+  },
+  principalButtons: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    ...Platform.select({
+      ios: {
+        justifyContent: 'space-between',
+        marginTop: 6,
+        marginBottom: 14,
+      },
+      android: {
+        justifyContent: 'center',
+        marginBottom: 7,
+      }
+    }),
+  },
+  overview: {
+    color: '#bbbbc1',
+    backgroundColor: 'transparent',
+    ...Platform.select({
+      ios: {
+        fontSize: 14,
+      },
+      android: {
+        fontFamily: 'Roboto-Regular',
+        fontSize: 16,
+        lineHeight: 24,
+      }
+    }),
+  },
+  // contenido del pie: reparto, estado de la serie, y por ultimo, temporadas?
+  footerContent: {
+    flex: 1,
+    flexDirection: 'row',
+    paddingLeft: 20,
+    paddingRight: 20,
+    marginTop: 20,
+  },
+  footerTitle: {
+    fontSize: 16,
+    color: '#919191',
+    ...Platform.select({
+      ios: {
+        fontSize: 14,
+      },
+      android: {
+        fontFamily: 'Roboto-Regular',
+        fontSize: 16,
+        //opacity: 0.9,
+      }
+    }),
+  },
+  footerData: {
+    color: '#bbbbc1',
+    ...Platform.select({
+      ios: {
+        fontSize: 14,
+      },
+      android: {
+        fontFamily: 'Roboto-Regular',
+        fontSize: 16,
+        //opacity: 0.9,
+      }
+    }),
+  },
+  // temporadas!
+  seasonsContent: {
+    flex: 1,
+    marginTop: 20,
+  },
+  scrollH: {
+    backgroundColor: '#1C1C1C',
+    padding: 2,
+    paddingRight: 0,
+  },
+  scrollPaddingBottom: {
+    paddingBottom: 50,
+  }
 });
 
 export default Series;


### PR DESCRIPTION
Ficha Serie
---
Vista en el cliente de una serie en concreto.

Nos basaremos en el boceto adjunto:
![Boceto - Ficha serie](https://trello-attachments.s3.amazonaws.com/587250aed272f44d7f90b77d/900x950/61e665836b833190c684d6076ad00e77/boceto---Ficha-serie.png)

Metas principales
---
Necesitaremos `ScrollView` vertical para la vista principal, y en el `bottom` uno horizontal para las temporadas como se aprecia en el boceto.

De cabecera irá el `fanart` de la serie en oscuro, con el `poster`de la serie posicionado por encima a la izquierda. Con el scroll vertical, intentaremos conseguir el efecto `parallax` para cuando hagamos scroll hacia arriba y vayamos a tapar el `fanart`. Para ello, necesitaremos aplicar funciones como `interpolate` a parámetros del `ScrollView`, de `Animated.View`'s, de `Image.View`'s, etc.

Cambios necesarios
---
Después de trabajar en el boceto de esta vista, se ha llegado a la conclusión de que entre el `fanart` de la cabecera y las imágenes utilizadas por toda la vista, prevalecerán los colores oscuros incluso en el fondo de la vista. Por lo que deberemos trabajar el cambiar los colores principales de la aplicación, y modificar los de la vista `Search` que es la única que tenemos para adecuarla a los mismos colores. Esperemos que sean los definitivos para el resto de la aplicación...

Dependencias importantes !
---
Enlazar los resultados de la **búsqueda** para poder pulsar en ellos y que nos lleve a su ficha

Modo de implementación
---
Hemos aprendido que las vistas en iOS y Android difieren en pocos detalles, como algunos estilos, y algunos `props` de componentes. A causa de esto, implementaremos de la manera más compatible la vista para ambos dispositivos en un solo fichero, apuntando los cambios necesarios y cuando llegue el momento de tenerla terminada, duplicaremos la vista para separarlas y aplicar sus diferencias.

Modo de implementación experimental
---
Existe *en principio* un modo de escribir todo el código tanto de iOS como de Android en la misma vista/fichero, con [`Platform module`](https://facebook.github.io/react-native/docs/platform-specific-code.html#platform-module). Iremos probándolo a medida que estemos implementando esta vista, y decidiremos si acabar por separarlas como hemos dicho en el punto anterior o queda un código limpio.