### PR TITLE
Almacenar/Borrar datos usuario

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -25,6 +25,8 @@ export default class TrendingSeriesClient extends Component {
     this.state = {
       initialRoute: '',
       loading: true,
+      userId: 0,
+      userName: '',
     };
   }
 
@@ -59,10 +61,15 @@ export default class TrendingSeriesClient extends Component {
           }).then((response) => response.json())
           .finally((responseData) => {
             if (this.processCheckJWTResponse(responseData)) {
-              // token correcto, vamos a la app
-              this.setInitialRoute('root');
+              // token correcto
+              // cargamos datos usuario y vamos a la app
+              AsyncStorage.multiGet(['userId', 'userName']).then((userData) => {
+                this.setState({userId: userData[0][1], userName: userData[1][1]});
+                this.setInitialRoute('root');
+              });
             } else {
               // token incorrecto, vamos a login
+              this.setState({userId: 0, userName: ''});
               this.setInitialRoute('login');
             }
           }).catch((error) => {
@@ -122,7 +129,7 @@ export default class TrendingSeriesClient extends Component {
           <CustomComponents.Navigator
             ref={component => this._navigator = component}
             style={{backgroundColor: '#1d1d1d'}}
-            initialRoute={{ name: this.state.initialRoute}}
+            initialRoute={{ name: this.state.initialRoute }}
             renderScene={this.renderScene.bind(this)}
             configureScene={(route) => {
               if (route.name === 'login' || route.name === 'root') {

--- a/login.js
+++ b/login.js
@@ -71,9 +71,13 @@ class Login extends Component {
     this.setState({modalVisible: visible});
   }
 
-  async storeToken(item, value) {
+  async storeSession(data) {
     try {
-      await AsyncStorage.setItem(item, value);
+      await AsyncStorage.multiSet([
+        ['jwt', data.Authorization],
+        ['userId', data.userId.toString()],
+        ['userName', data.userName]
+      ]);
     } catch (error) {
       console.log('AsyncStorage error: ' + error.message);
     }
@@ -90,11 +94,12 @@ class Login extends Component {
     } else if (data.ok !== undefined) {
       // se ha hecho login
       // guardamos token
-      this.storeToken('jwt', data.Authorization).done();
-      this.setModalVisible(true, 'Entrar', 'Has iniciado sesión correctamente', false);
-      setTimeout(() => this.setModalVisible(false, '', '', false), 2000);
-      // navegamos a la app, TODO: resetear navigator stack
-      setTimeout(() => this.navigateTo('root', true), 2100);
+      this.storeSession(data).then(() => {
+        this.setModalVisible(true, 'Entrar', 'Has iniciado sesión correctamente', false);
+        setTimeout(() => this.setModalVisible(false, '', '', false), 2000);
+        // navegamos a la app
+        setTimeout(() => this.navigateTo('root', true), 2100);
+      });
     } else {
       this.setModalVisible(true, 'Entrar', 'Ha habido un error, inténtalo más tarde', false);
       setTimeout(() => this.setModalVisible(false, '', '', false), 2000);

--- a/requestTvShow.ios.js
+++ b/requestTvShow.ios.js
@@ -13,6 +13,7 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Platform,
+  AsyncStorage,
 } from 'react-native';
 import CustomComponents from 'react-native-deprecated-custom-components';
 import Icon from 'react-native-vector-icons/Ionicons';
@@ -24,6 +25,8 @@ class RequestTvShow extends Component {
 
     const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
     this.state = {
+      userId: 0,
+      userName: '',
       searchText: this.props.searchText,
       searchedText: '',
       showProgress: false,
@@ -34,6 +37,16 @@ class RequestTvShow extends Component {
       listviewOpacity: new Animated.Value(0),
       notFoundOpacity: new Animated.Value(0),
     }
+  }
+
+  async getUserId() {
+    await AsyncStorage.multiGet(['userId', 'userName']).then((userData) => {
+      this.setState({userId: userData[0][1], userName: userData[1][1]});
+    });
+  }
+
+  componentWillMount() {
+    this.getUserId();
   }
 
   /* mensaje popUp */
@@ -171,7 +184,7 @@ class RequestTvShow extends Component {
               },
               body: JSON.stringify({
                 tvdbId: rowData.tvdbId,
-                userId: 1,
+                userId: this.state.userId,
               })
             }).then((response) => response.json())
               .finally((responseData) => {

--- a/root.js
+++ b/root.js
@@ -19,8 +19,8 @@ class Root extends Component {
   async logout() {
     console.log("logout");
     try {
-      await AsyncStorage.removeItem('jwt').then(() => {
-        console.log('Storage \'jwt\' eliminado');
+      await AsyncStorage.multiRemove(['jwt', 'userId', 'userName']).then(() => {
+        console.log('Storage sesión eliminada');
       }).done();
       // token borrado, navegamos a login
       this.navigateTo('login', true);


### PR DESCRIPTION
Ahora que los usuarios se pueden registrar/identificar tenemos almacenar datos identificativos que nos sirvan para el cliente como su `id` o el nombre, por lo que tenemos que modificar la API para que nos devuelva esa información, y modificar el cliente para que la almacene o la borre en login/logout.

Además hay que adaptar las peticiones para que se hagan desde el usuario activo y no desde el usuario `1`