### PR TITLE
Restricciones por roles (uso de jwt)

### DIFF
--- a/search.android.js
+++ b/search.android.js
@@ -14,6 +14,7 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Platform,
+  AsyncStorage,
 } from 'react-native';
 import CustomComponents from 'react-native-deprecated-custom-components';
 import Icon from 'react-native-vector-icons/Ionicons';
@@ -28,6 +29,9 @@ class Search extends Component {
     super();
     const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
     this.state = {
+      userId: 0,
+      userName: '',
+      jwt: '',
       searchText: '',
       searchedText: '',
       showProgress: false,
@@ -37,6 +41,21 @@ class Search extends Component {
       listviewOpacity: new Animated.Value(0),
       notFoundOpacity: new Animated.Value(0),
     }
+  }
+
+  // obtener datos usuario
+  async getUserData() {
+    await AsyncStorage.multiGet(['userId', 'userName', 'jwt']).then((userData) => {
+      this.setState({
+        userId: userData[0][1],
+        userName: userData[1][1],
+        jwt: userData[2][1]
+      });
+    });
+  }
+
+  componentWillMount() {
+    this.getUserData();
   }
 
   /* mensaje popUp */
@@ -58,8 +77,14 @@ class Search extends Component {
       this.setState({searchedText: this.state.searchText});
 
       // hacemos fetch a la API
-      fetch('http://192.168.1.13:9000/api/search/tvshows/' + this.state.searchText, {method: "GET"})
-      .then((response) => response.json())
+      fetch('http://192.168.1.13:9000/api/search/tvshows/' + this.state.searchText, {
+        method: "GET",
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + this.state.jwt,
+        }
+      }).then((response) => response.json())
       .then((responseData) => {
         this.processData(responseData);
       }).then( () => {

--- a/search.ios.js
+++ b/search.ios.js
@@ -13,6 +13,7 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Platform,
+  AsyncStorage,
 } from 'react-native';
 import CustomComponents from 'react-native-deprecated-custom-components';
 import Icon from 'react-native-vector-icons/Ionicons';
@@ -27,6 +28,9 @@ class Search extends Component {
     super();
     const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
     this.state = {
+      userId: 0,
+      userName: '',
+      jwt: '',
       searchText: '',
       searchedText: '',
       showProgress: false,
@@ -36,6 +40,21 @@ class Search extends Component {
       listviewOpacity: new Animated.Value(0),
       notFoundOpacity: new Animated.Value(0),
     }
+  }
+
+  // obtener datos usuario
+  async getUserData() {
+    await AsyncStorage.multiGet(['userId', 'userName', 'jwt']).then((userData) => {
+      this.setState({
+        userId: userData[0][1],
+        userName: userData[1][1],
+        jwt: userData[2][1]
+      });
+    });
+  }
+
+  componentWillMount() {
+    this.getUserData();
   }
 
   /* mensaje popUp */
@@ -57,8 +76,14 @@ class Search extends Component {
       this.setState({searchedText: this.state.searchText});
 
       // hacemos fetch a la API
-      fetch('http://localhost:9000/api/search/tvshows/' + this.state.searchText, {method: "GET"})
-      .then((response) => response.json())
+      fetch('http://localhost:9000/api/search/tvshows/' + this.state.searchText, {
+        method: "GET",
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + this.state.jwt,
+        }
+      }).then((response) => response.json())
       .then((responseData) => {
         this.processData(responseData);
       }).then( () => {


### PR DESCRIPTION
Para ello hemos tenido que cargar al inicio de esta vista los datos del usuario almacenados en el asyncstorage, obteniendo el id de usuario, el nombre de usuario y el jwt

Después, para la petición de buscar se utiliza el jwt para poder pasar la restricción de rol en la API