### PR TITLE
Mostrar temporadas en la vista de serie

### DIFF
--- a/components/seasonButton.android.js
+++ b/components/seasonButton.android.js
@@ -48,7 +48,7 @@ class seasonButton extends Component {
                   }
                 ]
               }
-              source={{uri: this.props.source}}
+                 source={this.props.source}
             />
             <View style={styles.titleAndSubtitle}>
               <Text style={

--- a/components/seasonButton.ios.js
+++ b/components/seasonButton.ios.js
@@ -52,7 +52,7 @@ class seasonButton extends Component {
                   }
                 ]
               }
-              source={{uri: this.props.source}}
+              source={this.props.source}
             />
             <View style={styles.titleAndSubtitle}>
               <Text style={

--- a/tvshow.js
+++ b/tvshow.js
@@ -23,7 +23,7 @@ import ReadMore from '@expo/react-native-read-more-text';
 import StarRatingBar from 'react-native-star-rating-view/StarRatingBar';
 
 //import CircularButton from './components/circularButton';
-//import SeasonButton from './components/seasonButton';
+import SeasonButton from './components/seasonButton';
 
 const TouchableNativeFeedback = Platform.select({
   android: () => require('TouchableNativeFeedback'),
@@ -651,80 +651,35 @@ class TvShow extends Component {
                   </View>
                 </View>
 
-                {/*<View style={styles.seasonsContent}>
-                <ScrollView horizontal style={styles.scrollH}>
 
-                  <SeasonButton
-                    imageWidth={(Platform.OS === 'ios') ? 110 : 120}
-                    imageHeight={(Platform.OS === 'ios') ? 159 : 173}
-                    backgroundColor={'#212121'}
-                    opacityColor={'#fe3f80'}
-                    source={'https://thetvdb.com/banners/seasons/305288-1-3.jpg'}
-                    title={'Temporada 1'}
-                    titleSize={(Platform.OS === 'ios') ? 13 : 14}
-                    titleColor={'#dedede'}
-                    subtitle={'8 episodios'}
-                    subtitleSize={(Platform.OS === 'ios') ? 13 : 14}
-                    subtitleColor={'#bbbbc1'}
-                  />
+                {(this.state.tvShowData.seasons.length > 0) ? (
+                  <View style={styles.seasonsContent}>
+                    <ScrollView horizontal style={styles.scrollH}>
 
-                  <SeasonButton
-                    imageWidth={(Platform.OS === 'ios') ? 110 : 120}
-                    imageHeight={(Platform.OS === 'ios') ? 159 : 173}
-                    backgroundColor={'#212121'}
-                    opacityColor={'#fe3f80'}
-                    source={'https://thetvdb.com/banners/seasons/305288-1-3.jpg'}
-                    title={'Temporada 1'}
-                    titleSize={(Platform.OS === 'ios') ? 13 : 14}
-                    titleColor={'#dedede'}
-                    subtitle={'8 episodios'}
-                    subtitleSize={(Platform.OS === 'ios') ? 13 : 14}
-                    subtitleColor={'#bbbbc1'}
-                  />
+                      {this.state.tvShowData.seasons.map((season, index) => {
+                        return (
+                          <SeasonButton
+                            key={index}
+                            imageWidth={(Platform.OS === 'ios') ? 110 : 120}
+                            imageHeight={(Platform.OS === 'ios') ? 159 : 173}
+                            backgroundColor={'#212121'}
+                            opacityColor={'#fe3f80'}
+                            source={season.poster !== null ? {uri: (URLSERVER + season.poster.substring(2))} : require('./img/placeholderPoster.png')}
+                            title={'Temporada ' + season.seasonNumber}
+                            titleSize={(Platform.OS === 'ios') ? 13 : 14}
+                            titleColor={'#dedede'}
+                            subtitle={''}
+                            subtitleSize={(Platform.OS === 'ios') ? 13 : 14}
+                            subtitleColor={'#bbbbc1'}
+                          />
+                        )
+                      })}
+                    </ScrollView>
+                  </View>
+                ) : (
+                  null
+                )}
 
-                  <SeasonButton
-                    imageWidth={(Platform.OS === 'ios') ? 110 : 120}
-                    imageHeight={(Platform.OS === 'ios') ? 159 : 173}
-                    backgroundColor={'#212121'}
-                    opacityColor={'#fe3f80'}
-                    source={'https://thetvdb.com/banners/seasons/305288-1-3.jpg'}
-                    title={'Temporada 1'}
-                    titleSize={(Platform.OS === 'ios') ? 13 : 14}
-                    titleColor={'#dedede'}
-                    subtitle={'8 episodios'}
-                    subtitleSize={(Platform.OS === 'ios') ? 13 : 14}
-                    subtitleColor={'#bbbbc1'}
-                  />
-
-                  <SeasonButton
-                    imageWidth={(Platform.OS === 'ios') ? 110 : 120}
-                    imageHeight={(Platform.OS === 'ios') ? 159 : 173}
-                    backgroundColor={'#212121'}
-                    opacityColor={'#fe3f80'}
-                    source={'https://thetvdb.com/banners/seasons/305288-1-3.jpg'}
-                    title={'Temporada 1'}
-                    titleSize={(Platform.OS === 'ios') ? 13 : 14}
-                    titleColor={'#dedede'}
-                    subtitle={'8 episodios'}
-                    subtitleSize={(Platform.OS === 'ios') ? 13 : 14}
-                    subtitleColor={'#bbbbc1'}
-                  />
-
-                  <SeasonButton
-                    imageWidth={(Platform.OS === 'ios') ? 110 : 120}
-                    imageHeight={(Platform.OS === 'ios') ? 159 : 173}
-                    backgroundColor={'#212121'}
-                    opacityColor={'#fe3f80'}
-                    source={'https://thetvdb.com/banners/seasons/305288-1-3.jpg'}
-                    title={'Temporada 1'}
-                    titleSize={(Platform.OS === 'ios') ? 13 : 14}
-                    titleColor={'#dedede'}
-                    subtitle={'8 episodios'}
-                    subtitleSize={(Platform.OS === 'ios') ? 13 : 14}
-                    subtitleColor={'#bbbbc1'}
-                  />
-                </ScrollView>
-              </View>*/}
               </View>
               {(Platform.OS === 'android') ?
                 <View style={styles.scrollPaddingBottom} /> : null}


### PR DESCRIPTION
En la vista de una serie, en el cliente móvil, mostrar un listado de las temporadas con su imagen y número de temporada como en se ideó en el mockup. La idea es implementar una `listview` horizontal para navegar por las temporadas.

![Temporadas en cliente](https://trello-attachments.s3.amazonaws.com/579e7bc5d4eeff3a993bf667/5a1b76e35fd0227142a511a8/0ed162f70d077be52c1b6227cb466f97/mockup_vista_serie_f11.png)