### PR TITLE
Mostrar episodios en la vista de temporada

### DIFF
--- a/components/episodeCollapse.js
+++ b/components/episodeCollapse.js
@@ -1,0 +1,175 @@
+import React, {Component} from 'react';
+import {Animated, Image, Platform, StyleSheet, Text, View, TouchableOpacity, TouchableNativeFeedback} from 'react-native';
+
+class EpisodeCollapse extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      index      : props.index,
+      number     : props.number,
+      name       : props.title,
+      screenshot : props.screenshot,
+      date       : props.date,
+      expanded   : false,
+      animation  : new Animated.Value(),
+    };
+  }
+
+  toggle(){
+    let initialValue = this.state.expanded ? this.state.maxHeight + this.state.minHeight : this.state.minHeight;
+    let finalValue   = this.state.expanded ? this.state.minHeight : this.state.maxHeight + this.state.minHeight;
+
+    this.setState({
+      expanded: !this.state.expanded,
+    });
+
+    this.state.animation.setValue(initialValue);
+    Animated.spring(this.state.animation, {
+      toValue: finalValue,
+    }).start();
+  }
+
+  _setMaxHeight(event) {
+    if (!this.state.maxHeight) {
+      this.setState({
+        maxHeight: event.nativeEvent.layout.height,
+      });
+    }
+  }
+
+  _setMinHeight(event){
+    if (!this.state.minHeight) {
+      this.setState({
+        minHeight: event.nativeEvent.layout.height,
+        animation: new Animated.Value(event.nativeEvent.layout.height),
+      });
+    }
+  }
+
+  render() {
+
+    return (
+      (Platform.OS === 'ios') ? (
+        <Animated.View style={[(this.state.expanded) ? styles.episodeExpanded : styles.episode, {height: this.state.animation}]}>
+          <TouchableOpacity style={styles.episode} onPress={this.toggle.bind(this)}>
+
+            <View style={styles.episodeInner} onLayout={this._setMinHeight.bind(this)}>
+              <View style={styles.episodeScreenshotView}>
+                <Image style={styles.episodeScreenshot}
+                       source={this.props.screenshot} />
+              </View>
+              <View style={styles.episodeNameNumber}>
+                <Text style={styles.episodeName} numberOfLines={1}>{this.props.name}</Text>
+                <View style={styles.episodeSubtitle}>
+                  <Text style={styles.episodeNumber}>Episodio {this.props.number}</Text>
+                  <Text style={styles.episodeDate}>{this.props.date}</Text>
+                </View>
+              </View>
+              <View style={styles.episodeOption}>
+              </View>
+            </View>
+
+          </TouchableOpacity>
+          <View style={styles.body} onLayout={this._setMaxHeight.bind(this)}>
+            {this.props.children}
+          </View>
+        </Animated.View>
+
+      ) : (
+          <Animated.View style={[(this.state.expanded) ? styles.episodeExpanded : styles.episode, {height: this.state.animation}]}>
+            <TouchableNativeFeedback onLayout={this._setMinHeight.bind(this)}
+              onPress={this.toggle.bind(this)}
+              background={TouchableNativeFeedback.Ripple('rgba(255,149,0,1)', true)}
+              useForeground>
+
+              <View style={styles.episodeInner}>
+                <View style={styles.episodeScreenshotView}>
+                  <Image style={styles.episodeScreenshot}
+                         source={this.props.screenshot} />
+                </View>
+                <View style={styles.episodeNameNumber}>
+                  <Text style={styles.episodeName} numberOfLines={1}>{this.props.name}</Text>
+                  <View style={styles.episodeSubtitle}>
+                    <Text style={styles.episodeNumber}>Episodio {this.props.number}</Text>
+                    <Text style={styles.episodeDate}>{this.props.date}</Text>
+                  </View>
+                </View>
+                <View style={styles.episodeOption}>
+                </View>
+              </View>
+
+            </TouchableNativeFeedback>
+            <View style={styles.body} onLayout={this._setMaxHeight.bind(this)}>
+              {this.props.children}
+            </View>
+          </Animated.View>
+        )
+    );
+  }
+}
+
+let styles = StyleSheet.create({
+  body: {
+    padding: 10,
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+  },
+  episode: {
+    flex: 1,
+    //borderTopWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.2)',
+    overflow:'hidden',
+  },
+  episodeExpanded: {
+    flex: 1,
+    //borderTopWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.2)',
+    overflow:'hidden',
+    backgroundColor: 'rgba(255, 255, 255, 0.1)',
+  },
+  episodeInner: {
+    flexDirection: 'row',
+    padding: 10,
+    alignItems: 'center',
+  },
+  episodeScreenshotView: {
+    width: 80,
+    height: 45.04,
+  },
+  episodeScreenshot: {
+    flex: 1,
+    width: null,
+    height: null,
+    resizeMode: 'cover',
+    borderRadius: 3,
+  },
+  episodeNameNumber: {
+    flex: 1,
+    flexDirection: 'column',
+    paddingLeft: 10,
+    paddingRight: 2,
+  },
+  episodeName: {
+    color: '#dadade',
+    fontSize: 14.5,
+    fontWeight: '600',
+    letterSpacing: -0.4,
+  },
+  episodeSubtitle: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingRight: 10,
+  },
+  episodeNumber: {
+    color: 'rgba(255, 255, 255, 0.66)',
+  },
+  episodeDate: {
+    color: 'rgba(255, 255, 255, 0.66)',
+    fontSize: 13,
+  },
+  episodeOption: {
+
+  },
+});
+
+export default EpisodeCollapse;

--- a/season.js
+++ b/season.js
@@ -12,13 +12,12 @@ import {
   AsyncStorage,
   ActivityIndicator,
   Dimensions,
-  TouchableOpacity,
-  Image,
 } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import CustomComponents from 'react-native-deprecated-custom-components';
 import Icon from 'react-native-vector-icons/Ionicons';
 import ReadMore from '@expo/react-native-read-more-text';
+import EpisodeCollapse from './components/episodeCollapse';
 
 const TouchableNativeFeedback = Platform.select({
   android: () => require('TouchableNativeFeedback'),
@@ -277,47 +276,14 @@ class Season extends Component {
                   <View style={styles.episodesView}>
                     {this.state.seasonData.episodes.map((episode, index) => {
                       return (
-                        (Platform.OS === 'ios') ? (
-                          <TouchableOpacity style={styles.episode} key={index} onPress={ this.openEpisode.bind(this, 1) }>
-                            <View style={styles.episodeInner}>
-                              <View style={styles.episodeScreenshotView}>
-                                <Image style={styles.episodeScreenshot}
-                                  source={episode.screenshot !== null ? {uri: this.formatImageUri(episode.screenshot)} : null} />
-                              </View>
-                              <View style={styles.episodeNameNumber}>
-                                <Text style={styles.episodeName} numberOfLines={1}>{episode.name}</Text>
-                                <Text style={styles.episodeNumber}>Episodio {episode.episodeNumber}</Text>
-                              </View>
-                              <View style={styles.episodeOption}>
-
-                              </View>
-
-                            </View>
-                          </TouchableOpacity>
-                        ) : (
-                          <View style={styles.episode} key={index} onPress={ this.openEpisode.bind(this, 1) }>
-                            <TouchableNativeFeedback
-                              onPress={ this.openEpisode.bind(this, 1) }
-                              background={TouchableNativeFeedback.Ripple('rgba(255,149,0,1)', true)}
-                              useForeground>
-
-                              <View style={styles.episodeInner}>
-                                <View style={styles.episodeScreenshotView}>
-                                  <Image style={styles.episodeScreenshot}
-                                         source={episode.screenshot !== null ? {uri: this.formatImageUri(episode.screenshot)} : null} />
-                                </View>
-                                <View style={styles.episodeNameNumber}>
-                                  <Text style={styles.episodeName} numberOfLines={1}>{episode.name}</Text>
-                                  <Text style={styles.episodeNumber}>Episodio {episode.episodeNumber}</Text>
-                                </View>
-                                <View style={styles.episodeOption}>
-
-                                </View>
-
-                              </View>
-                            </TouchableNativeFeedback>
-                          </View>
-                        )
+                        <EpisodeCollapse
+                          key={index}
+                          screenshot={episode.screenshot !== null ? {uri: this.formatImageUri(episode.screenshot)} : null}
+                          name={episode.name}
+                          number={episode.episodeNumber}
+                          date={(episode.firstAired !== null) ? new Date(this.state.seasonData.firstAired).toLocaleDateString() : null}>
+                          <Text style={styles.episodeOverview}>{episode.overview}</Text>
+                        </EpisodeCollapse>
                       )
                     })}
                   </View>
@@ -646,48 +612,11 @@ const styles = StyleSheet.create({
     }),
   },
   episodesView: {
-    marginTop: 14,
+    marginTop: 20,
     backgroundColor: 'rgba(20, 20, 20, 0.7)',
   },
-  episode: {
-    flex: 1,
-    //borderTopWidth: 1,
-    borderColor: 'rgba(255, 255, 255, 0.2)',
-  },
-  episodeInner: {
-    flexDirection: 'row',
-    padding: 10,
-    alignItems: 'center',
-  },
-  episodeScreenshotView: {
-    width: 80,
-    height: 50,
-  },
-  episodeScreenshot: {
-    flex: 1,
-    width: null,
-    height: null,
-    resizeMode: 'cover',
-    borderRadius: 3,
-  },
-  episodeNameNumber: {
-    flex: 1,
-    flexDirection: 'column',
-    paddingLeft: 10,
-    paddingRight: 2,
-  },
-  episodeName: {
-    color: '#dadade',
-    fontSize: 14.5,
-    fontWeight: '600',
-    letterSpacing: -0.4,
-  },
-  episodeNumber: {
+  episodeOverview: {
     color: 'rgba(255, 255, 255, 0.66)',
-    marginRight: 10,
-  },
-  episodeOption: {
-
   },
   modalLoader: {
     position: 'absolute',

--- a/season.js
+++ b/season.js
@@ -202,7 +202,7 @@ class Season extends Component {
       <ReadMore numberOfLines={3}
                 renderTruncatedFooter={this.overviewTruncatedFooter}
                 renderRevealedFooter={this.overviewRevealedFooter}>
-        <Text style={styles.overview}>{this.state.seasonData.overview}</Text>
+        <Text style={styles.overview}>{(this.state.seasonData.overview !== null) ? this.state.seasonData.overview : 'Sin sinopsis'}</Text>
       </ReadMore>
     ) : (
       null
@@ -278,11 +278,11 @@ class Season extends Component {
                       return (
                         <EpisodeCollapse
                           key={index}
-                          screenshot={episode.screenshot !== null ? {uri: this.formatImageUri(episode.screenshot)} : null}
+                          screenshot={episode.screenshot !== null ? {uri: this.formatImageUri(episode.screenshot)} : require('./img/placeholderPoster.png')}
                           name={episode.name}
                           number={episode.episodeNumber}
-                          date={(episode.firstAired !== null) ? new Date(this.state.seasonData.firstAired).toLocaleDateString() : null}>
-                          <Text style={styles.episodeOverview}>{episode.overview}</Text>
+                          date={(episode.firstAired !== null) ? new Date(episode.firstAired).toLocaleDateString() : null}>
+                          <Text style={styles.episodeOverview}>{(episode.overview !== null) ? episode.overview : 'Sin sinopsis'}</Text>
                         </EpisodeCollapse>
                       )
                     })}

--- a/season.js
+++ b/season.js
@@ -13,6 +13,7 @@ import {
   ActivityIndicator,
   Dimensions,
   TouchableOpacity,
+  Image,
 } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import CustomComponents from 'react-native-deprecated-custom-components';
@@ -238,6 +239,7 @@ class Season extends Component {
               {transform: [{translateY: imageTranslate}]},
               {opacity: this.state.fanartOpacity},
             ]}
+                            blurRadius={Platform.OS === 'ios' ? 6 : 2}
                             source={this.state.seasonData.poster !== null ? {uri: this.state.seasonData.poster} : require('./img/placeholderPoster.png')}
                             onLoadEnded={this.onFanartLoadEnded()}
             />
@@ -278,29 +280,37 @@ class Season extends Component {
                         (Platform.OS === 'ios') ? (
                           <TouchableOpacity style={styles.episode} key={index} onPress={ this.openEpisode.bind(this, 1) }>
                             <View style={styles.episodeInner}>
+                              <View style={styles.episodeScreenshotView}>
+                                <Image style={styles.episodeScreenshot}
+                                  source={episode.screenshot !== null ? {uri: this.formatImageUri(episode.screenshot)} : null} />
+                              </View>
                               <View style={styles.episodeNameNumber}>
                                 <Text style={styles.episodeName} numberOfLines={1}>{episode.name}</Text>
                                 <Text style={styles.episodeNumber}>Episodio {episode.episodeNumber}</Text>
                               </View>
-                              <View>
+                              <View style={styles.episodeOption}>
 
                               </View>
 
                             </View>
                           </TouchableOpacity>
                         ) : (
-                          <View style={styles.episode} onPress={ this.openEpisode.bind(this, 1) }>
+                          <View style={styles.episode} key={index} onPress={ this.openEpisode.bind(this, 1) }>
                             <TouchableNativeFeedback
                               onPress={ this.openEpisode.bind(this, 1) }
                               background={TouchableNativeFeedback.Ripple('rgba(255,149,0,1)', true)}
                               useForeground>
 
                               <View style={styles.episodeInner}>
+                                <View style={styles.episodeScreenshotView}>
+                                  <Image style={styles.episodeScreenshot}
+                                         source={episode.screenshot !== null ? {uri: this.formatImageUri(episode.screenshot)} : null} />
+                                </View>
                                 <View style={styles.episodeNameNumber}>
                                   <Text style={styles.episodeName} numberOfLines={1}>{episode.name}</Text>
                                   <Text style={styles.episodeNumber}>Episodio {episode.episodeNumber}</Text>
                                 </View>
-                                <View>
+                                <View style={styles.episodeOption}>
 
                                 </View>
 
@@ -643,14 +653,28 @@ const styles = StyleSheet.create({
     flex: 1,
     //borderTopWidth: 1,
     borderColor: 'rgba(255, 255, 255, 0.2)',
-    marginBottom: 2,
   },
   episodeInner: {
     flexDirection: 'row',
-    padding: 14,
+    padding: 10,
+    alignItems: 'center',
+  },
+  episodeScreenshotView: {
+    width: 80,
+    height: 50,
+  },
+  episodeScreenshot: {
+    flex: 1,
+    width: null,
+    height: null,
+    resizeMode: 'cover',
+    borderRadius: 3,
   },
   episodeNameNumber: {
+    flex: 1,
     flexDirection: 'column',
+    paddingLeft: 10,
+    paddingRight: 2,
   },
   episodeName: {
     color: '#dadade',
@@ -661,6 +685,9 @@ const styles = StyleSheet.create({
   episodeNumber: {
     color: 'rgba(255, 255, 255, 0.66)',
     marginRight: 10,
+  },
+  episodeOption: {
+
   },
   modalLoader: {
     position: 'absolute',

--- a/season.js
+++ b/season.js
@@ -12,6 +12,7 @@ import {
   AsyncStorage,
   ActivityIndicator,
   Dimensions,
+  TouchableOpacity,
 } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import CustomComponents from 'react-native-deprecated-custom-components';
@@ -117,14 +118,18 @@ class Season extends Component {
       // procesamos URLs imagenes
       data.poster = this.formatImageUri(data.poster);
 
-      // procesamos orden temporadas
-      /*data.seasons.sort(function(a, b) {
-        return a.seasonNumber - b.seasonNumber;
-      });*/
+      // procesamos orden episodios
+      data.episodes.sort(function(a, b) {
+        return a.episodeNumber - b.episodeNumber;
+      });
 
       // cargamos datos en el state
       this.setState({seasonData: data});
     }
+  }
+
+  openEpisode(id) {
+
   }
 
   // process image uri
@@ -233,7 +238,7 @@ class Season extends Component {
               {transform: [{translateY: imageTranslate}]},
               {opacity: this.state.fanartOpacity},
             ]}
-                            source={this.state.seasonData.poster !== null ? {uri: this.state.seasonData.poster} : require('./img/placeholderFanart.png')}
+                            source={this.state.seasonData.poster !== null ? {uri: this.state.seasonData.poster} : require('./img/placeholderPoster.png')}
                             onLoadEnded={this.onFanartLoadEnded()}
             />
 
@@ -265,6 +270,50 @@ class Season extends Component {
                 <View style={styles.bodyContent}>
                   { overview }
                 </View>
+
+                {(this.state.seasonData.episodes.length > 0) ? (
+                  <View style={styles.episodesView}>
+                    {this.state.seasonData.episodes.map((episode, index) => {
+                      return (
+                        (Platform.OS === 'ios') ? (
+                          <TouchableOpacity style={styles.episode} key={index} onPress={ this.openEpisode.bind(this, 1) }>
+                            <View style={styles.episodeInner}>
+                              <View style={styles.episodeNameNumber}>
+                                <Text style={styles.episodeName} numberOfLines={1}>{episode.name}</Text>
+                                <Text style={styles.episodeNumber}>Episodio {episode.episodeNumber}</Text>
+                              </View>
+                              <View>
+
+                              </View>
+
+                            </View>
+                          </TouchableOpacity>
+                        ) : (
+                          <View style={styles.episode} onPress={ this.openEpisode.bind(this, 1) }>
+                            <TouchableNativeFeedback
+                              onPress={ this.openEpisode.bind(this, 1) }
+                              background={TouchableNativeFeedback.Ripple('rgba(255,149,0,1)', true)}
+                              useForeground>
+
+                              <View style={styles.episodeInner}>
+                                <View style={styles.episodeNameNumber}>
+                                  <Text style={styles.episodeName} numberOfLines={1}>{episode.name}</Text>
+                                  <Text style={styles.episodeNumber}>Episodio {episode.episodeNumber}</Text>
+                                </View>
+                                <View>
+
+                                </View>
+
+                              </View>
+                            </TouchableNativeFeedback>
+                          </View>
+                        )
+                      )
+                    })}
+                  </View>
+                ) : (
+                  null
+                )}
 
               </View>
               {(Platform.OS === 'android') ?
@@ -537,14 +586,14 @@ const styles = StyleSheet.create({
   // contenido del cuerpo debajo de la cabecera
   bodyContent: {
     flex: 1,
-    minHeight: HEADER_MAX_HEIGHT - 80 - 14 - 147 - 10 - 6 - 6,
+    //minHeight: HEADER_MAX_HEIGHT - 80 - 14 - 147 - 10 - 6 - 6,
     paddingLeft: 14,
     paddingRight: 14,
     paddingTop: 6,
     backgroundColor: 'transparent',
     ...Platform.select({
       android: {
-        minHeight: HEADER_MAX_HEIGHT - 80 - 14 - 147 - 10 - 6 - 6 - 50,
+        //minHeight: HEADER_MAX_HEIGHT - 80 - 14 - 147 - 10 - 6 - 6 - 50,
       },
     }),
   },
@@ -585,6 +634,33 @@ const styles = StyleSheet.create({
         fontFamily: 'Roboto-Medium',
       },
     }),
+  },
+  episodesView: {
+    marginTop: 14,
+    backgroundColor: 'rgba(20, 20, 20, 0.7)',
+  },
+  episode: {
+    flex: 1,
+    //borderTopWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.2)',
+    marginBottom: 2,
+  },
+  episodeInner: {
+    flexDirection: 'row',
+    padding: 14,
+  },
+  episodeNameNumber: {
+    flexDirection: 'column',
+  },
+  episodeName: {
+    color: '#dadade',
+    fontSize: 14.5,
+    fontWeight: '600',
+    letterSpacing: -0.4,
+  },
+  episodeNumber: {
+    color: 'rgba(255, 255, 255, 0.66)',
+    marginRight: 10,
   },
   modalLoader: {
     position: 'absolute',

--- a/tvshow.js
+++ b/tvshow.js
@@ -688,7 +688,7 @@ class TvShow extends Component {
                             title={season.seasonNumber !== 0 ? 'Temporada ' + season.seasonNumber : 'Especiales'}
                             titleSize={(Platform.OS === 'ios') ? 13 : 14}
                             titleColor={'#dedede'}
-                            subtitle={''}
+                            subtitle={season.episodeCount + ' episodios'}
                             subtitleSize={(Platform.OS === 'ios') ? 13 : 14}
                             subtitleColor={'#bbbbc1'}
                           />


### PR DESCRIPTION
Mostrar lista de episodios en la vista de una temporada y que al pinchar en un episodio de la lista se abra un modal con toda la información del episodio incluyendo número, nombre, fecha, captura de pantalla, resumen.

Mostrar también en la vista de una serie, un contador de capítulos por cada temporada.

![Mockup Vista Temporada y episodios](https://trello-attachments.s3.amazonaws.com/579e7bc5d4eeff3a993bf667/5a1e2488068826a1446228a7/40af68efe01a31088e16aa00ad74dc1e/mockup_vista_temporada_y_episodios_f12.png)